### PR TITLE
adds capture_out and capture_err macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis](https://travis-ci.org/Ismael-VC/Suppressor.jl.svg?branch=master)](https://travis-ci.org/Ismael-VC/Suppressor.jl) [![AppVeyor](https://ci.appveyor.com/api/projects/status/e93wedour6lrdpj7/branch/master?svg=true)](https://ci.appveyor.com/project/Ismael-VC/suppressor-jl/branch/master) [![Coveralls](https://coveralls.io/repos/github/Ismael-VC/Suppressor.jl/badge.svg?branch=master)](https://coveralls.io/github/Ismael-VC/Suppressor.jl?branch=master) [![Codecov](http://codecov.io/github/Ismael-VC/Suppressor.jl/coverage.svg?branch=master)](http://codecov.io/github/Ismael-VC/Suppressor.jl?branch=master)
 
-Julia macros for suppressing output (STDOUT), warnings (STDERR) or both streams at the same time.
+Julia macros for suppressing and/or capturing output (STDOUT), warnings (STDERR) or both streams at the same time.
 
 ## Installation
 
@@ -47,5 +47,25 @@ ErrorException                                          Stacktrace (most recent 
 
 Remember that errors are still printed!
 
-julia>
 ```
+
+The `suppress` macros return whatever the given expression returns, but Suppressor also provides `@capture_out` and `@capture_err` macros that work similiarly to their `@suppress_` cousins except they return any output as a string:
+
+```julia
+julia> output = @capture_out begin
+    println("should get captured, not printed")
+end;
+
+julia> output == "should get captured, not printed\n"
+true
+
+julia> output = @capture_err begin
+    warn("should get captured, not printed")
+end;
+
+julia> output == "\e[1m\e[31mWARNING: should get captured, not printed\e[0m\n"
+true
+
+```
+
+Note that in this case the warning is printed with the escape characters to set the color because color is enabled at the REPL.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,4 +31,4 @@ build_script:
       Pkg.clone(pwd(), \"Suppressor\"); Pkg.build(\"Suppressor\")"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"Suppressor\")"
+  - C:\projects\julia\bin\julia --color=yes -e "Pkg.test(\"Suppressor\")"

--- a/src/Suppressor.jl
+++ b/src/Suppressor.jl
@@ -3,6 +3,7 @@ __precompile__()
 module Suppressor
 
 export @suppress, @suppress_out, @suppress_err
+export @capture_out, @capture_err
 
 macro suppress(block)
     quote
@@ -62,6 +63,42 @@ macro suppress_err(block)
             err_stream = redirect_stderr(ORIGINAL_STDERR)
 
             return value
+        end
+    end
+end
+
+macro capture_out(block)
+    quote
+        if ccall(:jl_generating_output, Cint, ()) == 0
+            ORIGINAL_STDOUT = STDOUT
+            out_rd, out_wr = redirect_stdout()
+            out_reader = @async readstring(out_rd)
+
+            $(esc(block))
+
+            REDIRECTED_STDOUT = STDOUT
+            out_stream = redirect_stdout(ORIGINAL_STDOUT)
+            close(out_wr)
+
+            wait(out_reader)
+        end
+    end
+end
+
+macro capture_err(block)
+    quote
+        if ccall(:jl_generating_output, Cint, ()) == 0
+            ORIGINAL_STDERR = STDERR
+            err_rd, err_wr = redirect_stderr()
+            err_reader = @async readstring(err_rd)
+
+            $(esc(block))
+
+            REDIRECTED_STDERR = STDERR
+            err_stream = redirect_stderr(ORIGINAL_STDERR)
+            close(err_wr)
+
+            wait(err_reader)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,16 @@
 using Suppressor
 using Base.Test
 
+output = @capture_out begin
+    println("should get captured, not printed")
+end
+@test output == "should get captured, not printed\n"
+
+output = @capture_err begin
+    warn("should get captured, not printed")
+end
+@test output == "WARNING: should get captured, not printed\n"
+
 @suppress begin
     println("This string doesn't get printed!")
     warn("This warning is ignored.")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ end
 output = @capture_err begin
     warn("should get captured, not printed")
 end
-@test output == "WARNING: should get captured, not printed\n"
+@test output == "\e[1m\e[31mWARNING: should get captured, not printed\e[0m\n"
 
 @suppress begin
     println("This string doesn't get printed!")


### PR DESCRIPTION
I often want to capture the STDOUT or STDERR streams (usually for testing) so I added some macros for that. They work similiarly to the `suppress_*` macros except that they return the captured data instead of the expression return value.

That reminds me - I should add info to the README. I'll do that shortly.
