### PR TITLE
Test in v0.4.7 also.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.4.7
   - 0.5
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.5
+julia 0.4
+Compat 0.7.9

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
   matrix:
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4.7-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4.7-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/Suppressor.jl
+++ b/src/Suppressor.jl
@@ -1,6 +1,7 @@
 __precompile__()
 
 module Suppressor
+using Compat
 
 export @suppress, @suppress_out, @suppress_err
 export @capture_out, @capture_err


### PR DESCRIPTION
Follow up of https://github.com/Ismael-VC/Suppressor.jl/pull/6, this PR adds the v0.4.7 to the matrix configurations of both AppVeyor and Travis CI.
