### PR TITLE
remove returns (fixes #9), make sure the user expr always runs

### DIFF
--- a/src/Suppressor.jl
+++ b/src/Suppressor.jl
@@ -16,17 +16,18 @@ macro suppress(block)
             ORIGINAL_STDERR = STDERR
             err_rd, err_wr = redirect_stderr()
             err_reader = @async readstring(err_rd)
+        end
 
-            value = $(esc(block))
+        value = $(esc(block))
 
+        if ccall(:jl_generating_output, Cint, ()) == 0
             redirect_stdout(ORIGINAL_STDOUT)
             close(out_wr)
 
             redirect_stderr(ORIGINAL_STDERR)
             close(err_wr)
-
-            return value
         end
+        value
     end
 end
 
@@ -36,14 +37,15 @@ macro suppress_out(block)
             ORIGINAL_STDOUT = STDOUT
             out_rd, out_wr = redirect_stdout()
             out_reader = @async readstring(out_rd)
+        end
 
-            value = $(esc(block))
+        value = $(esc(block))
 
+        if ccall(:jl_generating_output, Cint, ()) == 0
             redirect_stdout(ORIGINAL_STDOUT)
             close(out_wr)
-
-            return value
         end
+        value
     end
 end
 
@@ -53,14 +55,15 @@ macro suppress_err(block)
             ORIGINAL_STDERR = STDERR
             err_rd, err_wr = redirect_stderr()
             err_reader = @async readstring(err_rd)
+        end
 
-            value = $(esc(block))
+        value = $(esc(block))
 
+        if ccall(:jl_generating_output, Cint, ()) == 0
             redirect_stderr(ORIGINAL_STDERR)
             close(err_wr)
-
-            return value
         end
+        value
     end
 end
 
@@ -70,13 +73,17 @@ macro capture_out(block)
             ORIGINAL_STDOUT = STDOUT
             out_rd, out_wr = redirect_stdout()
             out_reader = @async readstring(out_rd)
+        end
 
-            $(esc(block))
+        $(esc(block))
 
+        if ccall(:jl_generating_output, Cint, ()) == 0
             redirect_stdout(ORIGINAL_STDOUT)
             close(out_wr)
 
             wait(out_reader)
+        else
+            ""
         end
     end
 end
@@ -87,13 +94,17 @@ macro capture_err(block)
             ORIGINAL_STDERR = STDERR
             err_rd, err_wr = redirect_stderr()
             err_reader = @async readstring(err_rd)
+        end
 
-            $(esc(block))
+        $(esc(block))
 
+        if ccall(:jl_generating_output, Cint, ()) == 0
             redirect_stderr(ORIGINAL_STDERR)
             close(err_wr)
 
             wait(err_reader)
+        else
+            ""
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,21 +14,25 @@ output = @capture_err begin
 end
 @test output == "WARNING: should get captured, not printed\n"
 
-@suppress begin
+@test @suppress begin
     println("This string doesn't get printed!")
     warn("This warning is ignored.")
-end
+    42
+end == 42
 
-@suppress_out begin
+@test @suppress_out begin
     println("This string doesn't get printed!")
     warn("This warning is important")
-end
+    42
+end == 42
 # WARNING: This warning is important
 
-@suppress_err begin
+@test @suppress_err begin
     println("This string gets printed!")
     warn("This warning is unimportant")
-end
+    42
+end == 42
+
 # This string gets printed!
 
 @test_throws ErrorException @suppress begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using Suppressor
 using Base.Test
 
+# make sure color is off to simplify testing for output
+eval(Base, :(have_color = false))
+
 output = @capture_out begin
     println("should get captured, not printed")
 end
@@ -9,8 +12,7 @@ end
 output = @capture_err begin
     warn("should get captured, not printed")
 end
-@test output == (Base.have_color ? "\e[1m\e[31mWARNING: should get captured, not printed\e[0m\n" : 
-                                   "WARNING: should get captured, not printed\n")
+@test output == "WARNING: should get captured, not printed\n"
 
 @suppress begin
     println("This string doesn't get printed!")
@@ -45,3 +47,39 @@ ErrorException                                          Stacktrace (most recent 
 
 Remember that errors are still printed!
 =#
+
+# test that the macros work inside a function
+function f1()
+    @suppress println("should not get printed")
+    42
+end
+
+@test f1() == 42
+
+function f2()
+    @suppress_out println("should not get printed")
+    42
+end
+
+@test f2() == 42
+
+function f3()
+    @suppress_err println("should not get printed")
+    42
+end
+
+@test f3() == 42
+
+function f4()
+    @capture_out println("should not get printed")
+    42
+end
+
+@test f4() == 42
+
+function f5()
+    @capture_err println("should not get printed")
+    42
+end
+
+@test f4() == 42


### PR DESCRIPTION
This PR does a couple things:

1. Removes `return` statements from the generated expression, so that it doesn't cause premature returns when it's used inside a function (fixes #9)
2. Adds tests that verify that the `suppress*` functions return their expression's value
3. Makes it so that the user's code is still run in the generated expression even if `jl_generating_output` returns true.
4. (minor) forces `Base.have_color` to be false so we don't have to worry about how exactly the output gets colored. This fixes a broken test on 0.6.