### PR TITLE
updates for 0.7 and more systematic test output

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis](https://travis-ci.org/JuliaIO/Suppressor.jl.svg?branch=master)](https://travis-ci.org/JuliaIO/Suppressor.jl) [![Build status](https://ci.appveyor.com/api/projects/status/e3uuqon84kt97402/branch/master?svg=true)](https://ci.appveyor.com/project/SalchiPapa/suppressor-jl/branch/master) [![CoverAlls](https://coveralls.io/repos/github/JuliaIO/Suppressor.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaIO/Suppressor.jl?branch=master) [![CodeCov](https://codecov.io/gh/JuliaIO/Suppressor.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaIO/Suppressor.jl)
 
-Julia macros for suppressing and/or capturing output (STDOUT), warnings (STDERR) or both streams at the same time.
+Julia macros for suppressing and/or capturing output (`stdout`), warnings (`stderr`) or both streams at the same time.
 
 ## Installation
 

--- a/src/Suppressor.jl
+++ b/src/Suppressor.jl
@@ -7,32 +7,50 @@ export @suppress, @suppress_out, @suppress_err
 export @capture_out, @capture_err
 export @color_output
 
+haslogging() = isdefined(Base, :CoreLogging)
+
 """
     @suppress expr
 
-Suppress the STDOUT and STDERR streams for the given expression.
+Suppress the `stdout` and `stderr` streams for the given expression.
 """
 macro suppress(block)
     quote
         if ccall(:jl_generating_output, Cint, ()) == 0
-            ORIGINAL_STDOUT = STDOUT
+            original_stdout = stdout
             out_rd, out_wr = redirect_stdout()
-            out_reader = @schedule read(out_rd, String)
+            out_reader = @async read(out_rd, String)
 
-            ORIGINAL_STDERR = STDERR
+            original_stderr = stderr
             err_rd, err_wr = redirect_stderr()
-            err_reader = @schedule read(err_rd, String)
+            err_reader = @async read(err_rd, String)
+
+            # approach adapted from https://github.com/JuliaLang/IJulia.jl/pull/667/files
+            if haslogging()
+                logstate = Base.CoreLogging._global_logstate
+                logger = logstate.logger
+                if logger.stream == original_stderr
+                    new_logstate = Base.CoreLogging.LogState(typeof(logger)(err_wr, logger.min_level))
+                    Core.eval(Base.CoreLogging, Expr(:(=), :(_global_logstate), new_logstate))
+                end
+            end
         end
 
         try
             $(esc(block))
         finally
             if ccall(:jl_generating_output, Cint, ()) == 0
-                redirect_stdout(ORIGINAL_STDOUT)
+                redirect_stdout(original_stdout)
                 close(out_wr)
 
-                redirect_stderr(ORIGINAL_STDERR)
+                redirect_stderr(original_stderr)
                 close(err_wr)
+
+                if haslogging()
+                    if logger.stream == stderr
+                        Core.eval(Base.CoreLogging, Expr(:(=), :(_global_logstate), logstate))
+                    end
+                end
             end
         end
     end
@@ -41,21 +59,21 @@ end
 """
     @suppress_out expr
 
-Suppress the STDOUT stream for the given expression.
+Suppress the `stdout` stream for the given expression.
 """
 macro suppress_out(block)
     quote
         if ccall(:jl_generating_output, Cint, ()) == 0
-            ORIGINAL_STDOUT = STDOUT
+            original_stdout = stdout
             out_rd, out_wr = redirect_stdout()
-            out_reader = @schedule read(out_rd, String)
+            out_reader = @async read(out_rd, String)
         end
 
         try
             $(esc(block))
         finally
             if ccall(:jl_generating_output, Cint, ()) == 0
-                redirect_stdout(ORIGINAL_STDOUT)
+                redirect_stdout(original_stdout)
                 close(out_wr)
             end
         end
@@ -65,22 +83,38 @@ end
 """
     @suppress_err expr
 
-Suppress the STDERR stream for the given expression.
+Suppress the `stderr` stream for the given expression.
 """
 macro suppress_err(block)
     quote
         if ccall(:jl_generating_output, Cint, ()) == 0
-            ORIGINAL_STDERR = STDERR
+            original_stderr = stderr
             err_rd, err_wr = redirect_stderr()
-            err_reader = @schedule read(err_rd, String)
+            err_reader = @async read(err_rd, String)
+
+            # approach adapted from https://github.com/JuliaLang/IJulia.jl/pull/667/files
+            if haslogging()
+                logstate = Base.CoreLogging._global_logstate
+                logger = logstate.logger
+                if logger.stream == original_stderr
+                    new_logstate = Base.CoreLogging.LogState(typeof(logger)(err_wr, logger.min_level))
+                    Core.eval(Base.CoreLogging, Expr(:(=), :(_global_logstate), new_logstate))
+                end
+            end
         end
 
         try
             $(esc(block))
         finally
             if ccall(:jl_generating_output, Cint, ()) == 0
-                redirect_stderr(ORIGINAL_STDERR)
+                redirect_stderr(original_stderr)
                 close(err_wr)
+
+                if haslogging()
+                    if logger.stream == stderr
+                        Core.eval(Base.CoreLogging, Expr(:(=), :(_global_logstate), logstate))
+                    end
+                end
             end
         end
     end
@@ -90,27 +124,27 @@ end
 """
     @capture_out expr
 
-Capture the STDOUT stream for the given expression.
+Capture the `stdout` stream for the given expression.
 """
 macro capture_out(block)
     quote
         if ccall(:jl_generating_output, Cint, ()) == 0
-            ORIGINAL_STDOUT = STDOUT
+            original_stdout = stdout
             out_rd, out_wr = redirect_stdout()
-            out_reader = @schedule read(out_rd, String)
+            out_reader = @async read(out_rd, String)
         end
 
         try
             $(esc(block))
         finally
             if ccall(:jl_generating_output, Cint, ()) == 0
-                redirect_stdout(ORIGINAL_STDOUT)
+                redirect_stdout(original_stdout)
                 close(out_wr)
             end
         end
 
         if ccall(:jl_generating_output, Cint, ()) == 0
-            wait(out_reader)
+            fetch(out_reader)
         else
             ""
         end
@@ -120,27 +154,43 @@ end
 """
     @capture_err expr
 
-Capture the STDERR stream for the given expression.
+Capture the `stderr` stream for the given expression.
 """
 macro capture_err(block)
     quote
         if ccall(:jl_generating_output, Cint, ()) == 0
-            ORIGINAL_STDERR = STDERR
+            original_stderr = stderr
             err_rd, err_wr = redirect_stderr()
-            err_reader = @schedule read(err_rd, String)
+            err_reader = @async read(err_rd, String)
+
+            if haslogging()
+                # approach adapted from https://github.com/JuliaLang/IJulia.jl/pull/667/files
+                logstate = Base.CoreLogging._global_logstate
+                logger = logstate.logger
+                if logger.stream == original_stderr
+                    new_logstate = Base.CoreLogging.LogState(typeof(logger)(err_wr, logger.min_level))
+                    Core.eval(Base.CoreLogging, Expr(:(=), :(_global_logstate), new_logstate))
+                end
+            end
         end
 
         try
             $(esc(block))
         finally
             if ccall(:jl_generating_output, Cint, ()) == 0
-                redirect_stderr(ORIGINAL_STDERR)
+                redirect_stderr(original_stderr)
                 close(err_wr)
+
+                if haslogging()
+                    if logger.stream == stderr
+                        Core.eval(Base.CoreLogging, Expr(:(=), :(_global_logstate), logstate))
+                    end
+                end
             end
         end
 
         if ccall(:jl_generating_output, Cint, ()) == 0
-            wait(err_reader)
+            fetch(err_reader)
         else
             ""
         end
@@ -157,7 +207,7 @@ combination with the `@capture_*` macros:
 
 @color_output false begin
     output = @capture_err begin
-        warn("should get captured, not printed")
+        @warn "should get captured, not printed"
     end
 end
 @test output == "WARNING: should get captured, not printed\n"
@@ -165,9 +215,9 @@ end
 macro color_output(enabled::Bool, block)
     quote
         prev_color = Base.have_color
-        eval(Base, :(have_color = $$enabled))
+        Core.eval(Base, :(have_color = $$enabled))
         retval = $(esc(block))
-        eval(Base, Expr(:(=), :have_color, prev_color))
+        Core.eval(Base, Expr(:(=), :have_color, prev_color))
 
         retval
     end


### PR DESCRIPTION
This updates for 0.7, including capturing logging output, which is a little more complicated because the logger caches STDERR, so it has to be handled separately.

This also reworks the testing so that it's more systematic. Previously there was a mix of things captured and things that were printed, and you had to read things carefully to figure out whether it was behaving correctly. The expected output is now as below. The incrementing numbers are so that you can tell if something got captured/suppressed that shouldn't have (there will be a skipped number) or if something doesn't get suppressed it'll show up in the output and say `SUPPRESSED` so it should be pretty obvious.

At some point in the future it would probably be good to use the shell to pipe this output to a file and compare to an expected output.

Also there's getting to be a lot of duplication in the code. I'm planning on a separate PR to clean up the code a bit, but I figured keeping this separate would make it easier to review.

```
01 PRINTED STDERR
02 PRINTED STDOUT
03 PRINTED STDOUT
04 PRINTED STDERR
05 PRINTED GREEN STDOUT
06 PRINTED GREEN STDERR
07 PRINTED NORMAL STDOUT
08 PRINTED NORMAL STDERR
09 PRINTED GREEN STDOUT
10 PRINTED GREEN STDERR
11 PRINTED NORMAL STDOUT
12 PRINTED NORMAL STDERR
13 PRINTED GREEN STDOUT
14 PRINTED GREEN STDERR
15 PRINTED NORMAL STDOUT
16 PRINTED NORMAL STDERR
17 PRINTED STDERR
18 PRINTED STDOUT
19 PRINTED STDOUT
20 PRINTED STDERR
21 PRINTED STDOUT
22 PRINTED STDERR
23 PRINTED STDOUT
24 PRINTED STDERR
25 PRINTED STDOUT
26 PRINTED STDERR
27 PRINTED STDOUT
28 PRINTED STDERR
29 PRINTED STDOUT
30 PRINTED STDERR
31 PRINTED STDOUT
32 PRINTED STDERR
[ Info: 33 PRINTED LOGINFO
[ Info: 34 PRINTED LOGINFO
[ Info: 35 PRINTED LOGINFO
Test Summary: | Pass  Total
Suppressor    |    7      7
   Testing Suppressor tests passed
```