### PR TITLE
Make suppress macro export variable in outer scope automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,3 @@ end
 end
 @test output == "\e[1m\e[33mWARNING: \e[39m\e[22m\e[33mshould get captured, not printed\e[39m\n"
 ```
-
-### Variable Scope
-
-The macros in Suppressor.jl need to wrap the given expression in a `try...finally` block to make sure that everything is cleaned up correctly. This means that any variables introduced within the macro expression aren't in-scope afterwards. To work around this you can use `local` to introduce the variable before the block, for example:
-
-```julia
-local x
-output = @capture_out x = loudfunction()
-println(x) # x is available here
-```

--- a/src/Suppressor.jl
+++ b/src/Suppressor.jl
@@ -64,6 +64,9 @@ macro suppress(block)
         # can still do `@suppress using Foo`).
         try
             @with_logstate(Base.CoreLogging.LogState(_logger), $(esc(block)))
+            for v in [:($key = $value) for (key,value) in Base.@locals]
+                Base.eval($__module__, v)
+            end
         finally
             if ccall(:jl_generating_output, Cint, ()) == 0
                 redirect_stdout(original_stdout)


### PR DESCRIPTION
Actually this fixes everything, so no need for the suggested workaround in #67, now:

```julia
julia> using Suppressor

julia> @suppress g = 1

julia> module M
           using Suppressor
           @suppress g = 1
       end
Main.M

julia> g
1

julia> Main.M.g
1
```

It should probably applied to all macros actually, but I'd like to know what mantainers think of this